### PR TITLE
Support Java16

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2.5.0
         with:
           # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file
-          java-version: '8'
+          java-version: '16'
           # Java distribution. See the list of supported distributions in README file
           distribution: 'temurin'
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: '16'
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven

--- a/buildSrc/src/main/groovy/org.cyberiantiger.minecraft.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.cyberiantiger.minecraft.java-conventions.gradle
@@ -33,7 +33,7 @@ repositories {
 
 group = 'org.cyberiantiger.minecraft'
 version = '1.13.4-SNAPSHOT'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_16
 
 publishing {
     publications {

--- a/duckchat-bukkit/pom.xml
+++ b/duckchat-bukkit/pom.xml
@@ -11,8 +11,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.number>${user.name}</project.build.number>
-    <java.version.source>1.8</java.version.source>
-    <java.version.target>1.8</java.version.target>
+    <java.version.source>16</java.version.source>
+    <java.version.target>16</java.version.target>
     <java.compiler.debug>false</java.compiler.debug>
   </properties>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.number>${user.name}</project.build.number>
-    <java.version.source>1.8</java.version.source>
-    <java.version.target>1.8</java.version.target>
+    <java.version.source>16</java.version.source>
+    <java.version.target>16</java.version.target>
     <java.compiler.debug>true</java.compiler.debug>
   </properties>
   <build>


### PR DESCRIPTION
新しいMinecraftがJava16や17になったが、古いMinecraftがJava8のまま変わっていないのであまり意味はないと思う。